### PR TITLE
Delete unused "n:" in getopt_long optstring in toeplitz test.

### DIFF
--- a/tests/toeplitz.c
+++ b/tests/toeplitz.c
@@ -422,7 +422,7 @@ static void parse_opts(int argc, char **argv)
 	bool have_toeplitz = false;
 	int index, c;
 
-	while ((c = getopt_long(argc, argv, "46C:d:i:k:n:stT:u:v", long_options, &index)) != -1) {
+	while ((c = getopt_long(argc, argv, "46C:d:i:k:stT:u:v", long_options, &index)) != -1) {
 		switch (c) {
 		case '4':
 			cfg_family = AF_INET;


### PR DESCRIPTION
Signed-off-by: Tanner Love <tannerlove@google.com>